### PR TITLE
Disable code analysis of third-party code

### DIFF
--- a/SettingsWatchdog/SettingsWatchdog.cpp
+++ b/SettingsWatchdog/SettingsWatchdog.cpp
@@ -137,7 +137,10 @@ void InstallService()
     BOOST_LOG_FUNC();
     ServiceManagerHandle const handle(SC_MANAGER_CREATE_SERVICE);
     auto const self_path = boost::dll::program_location();
+#pragma warning(push)
+#pragma warning(disable: 26812) // Enum is unscoped. Prefer enum class.
     BOOST_LOG_SEV(wdlog::get(), trace) << format(TEXT("Current file name is %1%")) % self_path.native();
+#pragma warning(pop)
 
     ServiceHandle const service(handle, TEXT("SettingsWatchdog"),
                                 TEXT("Settings Watchdog"), ServiceType,
@@ -565,7 +568,10 @@ void WINAPI SettingsWatchdogMain(DWORD dwArgc, LPTSTR* lpszArgv)
             DWORD session_count;
             BOOST_LOG_SEV(wdlog::get(), debug) << "enumerating sessions";
             DWORD level = 1;
+#pragma warning(push)
+#pragma warning(disable: 6387) // Param 1 could be zero
             WinCheck(WTSEnumerateSessionsEx(WTS_CURRENT_SERVER_HANDLE, &level, 0, &raw_session_info, &session_count), "getting session list");
+#pragma warning(pop)
             std::shared_ptr<WTS_SESSION_INFO_1> session_info(
                 raw_session_info,
                 [&session_count](void* info) {

--- a/SettingsWatchdog/stdafx.hpp
+++ b/SettingsWatchdog/stdafx.hpp
@@ -22,6 +22,9 @@
 #include <system_error>
 #include <vector>
 
+#include <codeanalysis/warnings.h>
+#pragma warning(push)
+#pragma warning(disable: ALL_CODE_ANALYSIS_WARNINGS)
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/core/noncopyable.hpp>
 #include <boost/dll/runtime_symbol_info.hpp>
@@ -47,3 +50,4 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/algorithm/for_each.hpp>
 #include <boost/range/algorithm_ext/push_back.hpp>
+#pragma warning(pop)


### PR DESCRIPTION
We disable all analysis warnings around Boost code, and then we disable the last couple of stragglers from the project code.

In one case, MSVC apparently chooses to warn about non-enum-class enums at the first place they're used instead of at their declaration. It's enough to disable the warning around that first use.

In another case, an API function is incorrectly annotated, so MSVC warns when an `_In_ HANDLE` parameter is passed a null value, even though that usage is specifically intended in the API. MSVC doesn't like it when `_In_` values receive null pointers.