### PR TITLE
Replace map_erase_if with standard function

### DIFF
--- a/SettingsWatchdog/SettingsWatchdog.cpp
+++ b/SettingsWatchdog/SettingsWatchdog.cpp
@@ -537,16 +537,6 @@ bool ensure_range(T const& min, T const& max, T const& value, std::string const&
     return false;
 }
 
-template <typename M, typename F>
-void map_erase_if(M& m, F predicate)
-{
-    for (auto it = m.begin(); it != m.end(); )
-        if (predicate(*it))
-            m.erase(it++);
-        else
-            ++it;
-}
-
 void WINAPI SettingsWatchdogMain(DWORD dwArgc, LPTSTR* lpszArgv)
 {
     BOOST_LOG_FUNC();
@@ -661,7 +651,7 @@ void WINAPI SettingsWatchdogMain(DWORD dwArgc, LPTSTR* lpszArgv)
                         BOOST_LOG_SEV(wdlog::get(), trace) << "Session list changed";
                         WinCheck(ResetEvent(context.SessionChange), "resetting session event");
                         logging_lock_guard session_guard(context.session_mutex, "session-list change");
-                        map_erase_if(context.sessions, [](std::map<DWORD, SessionData>::value_type const& item) {
+                        std::experimental::erase_if(context.sessions, [](auto const& item) {
                             return !item.second.running;
                         });
                         boost::for_each(

--- a/SettingsWatchdog/stdafx.hpp
+++ b/SettingsWatchdog/stdafx.hpp
@@ -13,6 +13,7 @@
 #include <sddl.h>
 
 #include <algorithm>
+#include <experimental/map>
 #include <functional>
 #include <iostream>
 #include <iomanip>


### PR DESCRIPTION
C++20 will have `std::erase_if`, but in the meantime, VS 2019 supports `std::experimental::erase_if`, which works the same as our current function.

The parameter type was also cumbersome, and as of C++14, we can use `auto` in lambda parameters.