### PR TITLE
Ignore generated git-commit.hpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ bld/
 **/packages/*
 # except build/, which is used as an MSBuild target.
 !**/packages/build/
+
+SettingsWatchdog/git-commit.hpp


### PR DESCRIPTION
This cleans up `git status` output.