### PR TITLE
Clean up map access

### DIFF
--- a/SettingsWatchdog/SettingsWatchdog.cpp
+++ b/SettingsWatchdog/SettingsWatchdog.cpp
@@ -251,7 +251,7 @@ DWORD WINAPI ServiceHandler(DWORD dwControl, DWORD dwEventType,
     BOOST_LOG_FUNC();
     auto const context = static_cast<ServiceContext<SettingsWatchdogContext>*>(lpContext);
 
-    WDLOG(trace, "Service control %1% (%2%)") % dwControl % get_with_default(control_names, dwControl, "unknown").c_str();
+    WDLOG(trace, "Service control %1% (%2%)") % dwControl % get(control_names, dwControl).value_or("unknown").c_str();
     switch (dwControl) {
         case SERVICE_CONTROL_INTERROGATE:
             return NO_ERROR;
@@ -271,7 +271,7 @@ DWORD WINAPI ServiceHandler(DWORD dwControl, DWORD dwEventType,
         }
         case SERVICE_CONTROL_SESSIONCHANGE:
         {
-            WDLOG(trace, "session-change code %1%") % get_with_default(session_change_codes, dwEventType, std::to_string(dwEventType)).c_str();
+            WDLOG(trace, "session-change code %1%") % get(session_change_codes, dwEventType).value_or(std::to_string(dwEventType)).c_str();
             auto const notification = static_cast<WTSSESSION_NOTIFICATION const*>(lpEventData);
             if (notification->cbSize != sizeof(WTSSESSION_NOTIFICATION)) {
                 // The OS is sending the wrong structure size, so let's pretend
@@ -452,7 +452,7 @@ void WINAPI SettingsWatchdogMain(DWORD dwArgc, LPTSTR* lpszArgv)
                     boost::numeric_cast<DWORD>(wait_handles.size()),
                     wait_handles.data(), false, INFINITE);
                 std::error_code ec(GetLastError(), std::system_category());
-                WDLOG(trace, "Wait returned %1%") % get_with_default(wait_results, WaitResult, std::to_string(WaitResult)).c_str();
+                WDLOG(trace, "Wait returned %1%") % get(wait_results, WaitResult).value_or(std::to_string(WaitResult)).c_str();
                 switch (WaitResult) {
                     case WAIT_OBJECT_0:
                     {

--- a/SettingsWatchdog/logging.cpp
+++ b/SettingsWatchdog/logging.cpp
@@ -77,5 +77,5 @@ BOOST_LOG_GLOBAL_LOGGER_INIT(wdlog, logger_type)
 
 std::basic_ostream<char>& operator<<(std::basic_ostream<char>& os, severity_level sev)
 {
-    return os << get_with_default(severity_names, sev, "unknown");
+    return os << get(severity_names, sev).value_or("unknown");
 }

--- a/SettingsWatchdog/string-maps.hpp
+++ b/SettingsWatchdog/string-maps.hpp
@@ -3,7 +3,9 @@
 #include "logging.hpp"
 
 #include <map>
+#include <optional>
 #include <string>
+#include <utility>
 
 #include <windows.h>
 
@@ -16,9 +18,9 @@ extern std::map<DWORD, std::string> const wait_results;
 extern std::map<severity_level, std::string> const severity_names;
 
 template <typename Map, typename T>
-typename Map::mapped_type get_with_default(Map const& map, typename Map::key_type const& key, T const& default_value)
+std::optional<typename Map::mapped_type> get(Map const& map, T&& key)
 {
-    if (auto it = map.find(key); it != map.end())
+    if (auto it = map.find(std::forward<T>(key)); it != map.end())
         return it->second;
-    return default_value;
+    return std::nullopt;
 }


### PR DESCRIPTION
The `get` function now returns an `optional`, so the task of choosing a default value is shifted to the caller instead of `get` needing to deal with it.