### PR TITLE
Prefer UTF-8 where possible

### DIFF
--- a/SettingsWatchdog/SettingsWatchdog.vcxproj
+++ b/SettingsWatchdog/SettingsWatchdog.vcxproj
@@ -64,7 +64,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>advapi32.lib;wtsapi32.lib</AdditionalDependencies>
+      <AdditionalDependencies>advapi32.lib;wtsapi32.lib;shell32.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 
@@ -125,7 +125,7 @@
     <PropertyGroup>
       <CommitCode><![CDATA[
 #include <windows.h>
-inline auto git_commit = TEXT(R"($(GitCommit))")%3b
+inline auto git_commit = R"($(GitCommit))"%3b
 ]]></CommitCode>
     </PropertyGroup>
     <WriteLinesToFile

--- a/SettingsWatchdog/handles.cpp
+++ b/SettingsWatchdog/handles.cpp
@@ -6,6 +6,7 @@
 #pragma warning(disable: ALL_CODE_ANALYSIS_WARNINGS)
 
 #include <boost/log/attributes/named_scope.hpp>
+#include <boost/nowide/convert.hpp>
 
 #pragma warning(pop)
 
@@ -29,19 +30,19 @@ ServiceManagerHandle::ServiceManagerHandle(DWORD permissions):
                       "opening service control manager")
 {}
 
-ServiceHandle::ServiceHandle(ServiceManagerHandle const& manager, TCHAR const* name,
-                             TCHAR const* display_name, DWORD type, DWORD start,
-                             TCHAR const* path) :
-    BaseServiceHandle(CreateService(manager, name, display_name,
+ServiceHandle::ServiceHandle(ServiceManagerHandle const& manager, char const* name,
+                             char const* display_name, DWORD type, DWORD start,
+                             std::filesystem::path const& path) :
+    BaseServiceHandle(CreateServiceW(manager, boost::nowide::widen(name).c_str(), boost::nowide::widen(display_name).c_str(),
                                     SERVICE_ALL_ACCESS, type, start,
-                                    SERVICE_ERROR_NORMAL, path, nullptr,
+                                    SERVICE_ERROR_NORMAL, path.c_str(), nullptr,
                                     nullptr, nullptr, nullptr, nullptr),
                       "creating service")
 {}
 
-ServiceHandle::ServiceHandle(ServiceManagerHandle const& manager, TCHAR const* name,
+ServiceHandle::ServiceHandle(ServiceManagerHandle const& manager, char const* name,
                              DWORD access):
-    BaseServiceHandle(OpenService(manager, name, access), "opening service")
+    BaseServiceHandle(OpenServiceW(manager, boost::nowide::widen(name).c_str(), access), "opening service")
 {}
 
 AutoCloseHandle::AutoCloseHandle(HANDLE handle) :

--- a/SettingsWatchdog/handles.hpp
+++ b/SettingsWatchdog/handles.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <filesystem>
+
 #include <windows.h>
 
 class BaseServiceHandle
@@ -24,10 +26,10 @@ public:
 class ServiceHandle: public BaseServiceHandle
 {
 public:
-    ServiceHandle(ServiceManagerHandle const& manager, TCHAR const* name,
-                  TCHAR const* display_name, DWORD type, DWORD start,
-                  TCHAR const* path);
-    ServiceHandle(ServiceManagerHandle const& manager, TCHAR const* name,
+    ServiceHandle(ServiceManagerHandle const& manager, char const* name,
+                  char const* display_name, DWORD type, DWORD start,
+                  std::filesystem::path const& path);
+    ServiceHandle(ServiceManagerHandle const& manager, char const* name,
                   DWORD access);
 };
 

--- a/SettingsWatchdog/logging.cpp
+++ b/SettingsWatchdog/logging.cpp
@@ -18,6 +18,7 @@
 #include <boost/log/support/date_time.hpp>
 #include <boost/log/utility/setup/console.hpp>
 #include <boost/log/utility/setup/file.hpp>
+#include <boost/nowide/iostream.hpp>
 #include <boost/phoenix/bind/bind_function.hpp>
 #include <boost/phoenix/operator/arithmetic.hpp>
 
@@ -61,17 +62,18 @@ BOOST_LOG_GLOBAL_LOGGER_INIT(wdlog, logger_type)
 
     auto const verbosity_filter = boost::phoenix::bind(&severity_filter, severity.or_none());
 
-    auto const console = bl::add_console_log();
-    console->set_formatter(g_formatter);
-    console->set_filter(verbosity_filter);
-
+    auto const console = bl::add_console_log(
+        boost::nowide::clog,
+        bl::keywords::filter = verbosity_filter,
+        bl::keywords::format = g_formatter
+    );
     auto const file = bl::add_file_log(
         bl::keywords::file_name = config.log_file().native(),
         bl::keywords::open_mode = std::ios_base::app | std::ios_base::out,
-        bl::keywords::auto_flush = true
+        bl::keywords::auto_flush = true,
+        bl::keywords::filter = verbosity_filter,
+        bl::keywords::format = g_formatter
     );
-    file->set_formatter(g_formatter);
-    file->set_filter(verbosity_filter);
     return lg;
 }
 

--- a/SettingsWatchdog/logging.hpp
+++ b/SettingsWatchdog/logging.hpp
@@ -24,16 +24,8 @@ enum class severity_level
 
 std::basic_ostream<char>& operator<<(std::basic_ostream<char>& os, severity_level sev);
 
-#ifdef UNICODE
-using logger_type = boost::log::sources::wseverity_logger_mt<severity_level>;
-#else
 using logger_type = boost::log::sources::severity_logger_mt<severity_level>;
-#endif
 
 BOOST_LOG_GLOBAL_LOGGER(wdlog, logger_type)
 
-#if UNICODE
-#define WDLOG(sev, msg) BOOST_LOG_SEV(wdlog::get(), (severity_level::sev)) << boost::wformat(TEXT(msg))
-#else
 #define WDLOG(sev, msg) BOOST_LOG_SEV(wdlog::get(), (severity_level::sev)) << boost::format((msg))
-#endif

--- a/SettingsWatchdog/registry.cpp
+++ b/SettingsWatchdog/registry.cpp
@@ -6,25 +6,19 @@
 #pragma warning(push)
 #pragma warning(disable: ALL_CODE_ANALYSIS_WARNINGS)
 
-#include <boost/format.hpp>
 #include <boost/log/sources/severity_feature.hpp>
+#include <boost/nowide/convert.hpp>
 
 #pragma warning(pop)
 
-#if UNICODE
-using format = boost::wformat;
-#else
-using format = boost::format;
-#endif
-
-HKEY OpenRegKey(HKEY hKey, LPCTSTR lpSubKey, DWORD ulOptions, REGSAM samDesired)
+HKEY OpenRegKey(HKEY hKey, char const* lpSubKey, DWORD ulOptions, REGSAM samDesired)
 {
     HKEY result;
-    RegCheck(RegOpenKeyEx(hKey, lpSubKey, ulOptions, samDesired, &result), "opening registry key");
+    RegCheck(RegOpenKeyExW(hKey, boost::nowide::widen(lpSubKey).c_str(), ulOptions, samDesired, &result), "opening registry key");
     return result;
 }
 
-RegKey::RegKey(HKEY key, TCHAR const* name, DWORD permissions):
+RegKey::RegKey(HKEY key, char const* name, DWORD permissions):
     m_key(OpenRegKey(key, name, 0, permissions))
 {}
 
@@ -45,9 +39,9 @@ RegKey::operator HKEY() const
     return m_key;
 }
 
-void DeleteRegistryValue(HKEY key, TCHAR const* name)
+void DeleteRegistryValue(HKEY key, char const* name)
 {
-    switch (LONG const result = RegDeleteValue(key, name); result) {
+    switch (LONG const result = RegDeleteValueW(key, boost::nowide::widen(name).c_str()); result) {
         case ERROR_SUCCESS:
             WDLOG(info, "Deleted %1% value") % name;
             break;

--- a/SettingsWatchdog/registry.hpp
+++ b/SettingsWatchdog/registry.hpp
@@ -2,7 +2,7 @@
 
 #include <windows.h>
 
-HKEY OpenRegKey(HKEY hKey, LPCTSTR lpSubKey, DWORD ulOptions, REGSAM samDesired);
+HKEY OpenRegKey(HKEY hKey, char const* lpSubKey, DWORD ulOptions, REGSAM samDesired);
 
 class RegKey
 {
@@ -11,10 +11,10 @@ class RegKey
     RegKey(RegKey const&) = delete;
     RegKey& operator=(RegKey const&) = delete;
 public:
-    RegKey(HKEY key, TCHAR const* name, DWORD permissions);
+    RegKey(HKEY key, char const* name, DWORD permissions);
     RegKey(RegKey&& other) noexcept;
     ~RegKey();
     operator HKEY() const;
 };
 
-void DeleteRegistryValue(HKEY key, TCHAR const* name);
+void DeleteRegistryValue(HKEY key, char const* name);

--- a/vcpkg-response.txt
+++ b/vcpkg-response.txt
@@ -4,6 +4,7 @@ boost-date-time
 boost-dll
 boost-format
 boost-log
+boost-nowide
 boost-numeric-conversion
 boost-phoenix
 boost-program-options

--- a/vcpkg-response.txt
+++ b/vcpkg-response.txt
@@ -9,3 +9,4 @@ boost-numeric-conversion
 boost-phoenix
 boost-program-options
 boost-range
+boost-winapi


### PR DESCRIPTION
This change introduces Boost.Nowide to use UTF-8 in place of Windows Unicode wherever possible. Some API functions become a little more complicated to call, but with only one kind of string to print anymore, the stream I/O (including logging) become more consistent.

This resolves #19.