### PR TITLE
Add milliseconds to log timestamp

### DIFF
--- a/SettingsWatchdog/logging.cpp
+++ b/SettingsWatchdog/logging.cpp
@@ -13,7 +13,9 @@
 #include <boost/log/attributes/named_scope.hpp>
 #include <boost/log/expressions/formatters/date_time.hpp>
 #include <boost/log/expressions/formatters/format.hpp>
+#include <boost/log/expressions/formatters/max_size_decorator.hpp>
 #include <boost/log/expressions/formatters/named_scope.hpp>
+#include <boost/log/expressions/formatters/stream.hpp>
 #include <boost/log/expressions/keyword.hpp>
 #include <boost/log/support/date_time.hpp>
 #include <boost/log/utility/setup/console.hpp>
@@ -31,9 +33,9 @@ BOOST_LOG_ATTRIBUTE_KEYWORD(thread_id, "ThreadId", decltype(boost::winapi::GetCu
 BOOST_LOG_ATTRIBUTE_KEYWORD(severity, "Severity", severity_level)
 
 static bl::formatter const g_formatter = (
-    bl::expressions::format("%1% [%2%:%3%] <%4%> %5%: %6%")
+    bl::expressions::format("%1%.%7% [%2%:%3%] <%4%> %5%: %6%")
     % bl::expressions::format_date_time<boost::posix_time::ptime>(
-        "TimeStamp", "%Y-%m-%d %H:%M:%S")  // RisK TODO Add milliseconds to output.
+        "TimeStamp", "%Y-%m-%d %H:%M:%S")
     % process_id
     % thread_id
     % severity
@@ -43,6 +45,11 @@ static bl::formatter const g_formatter = (
         bl::keywords::incomplete_marker = "",
         bl::keywords::depth = 1)
     % bl::expressions::message
+    % bl::expressions::max_size_decor(3, "")[
+        // %f gives six digits of precision. We want three.
+        bl::expressions::stream << bl::expressions::format_date_time<boost::posix_time::ptime>(
+            "TimeStamp", "%f")
+    ]
 );
 
 static bool severity_filter(bl::value_ref<severity_level, tag::severity> const& level)


### PR DESCRIPTION
I tried a couple of the [solutions at Stack Overflow][1], until finally using this one. Stack Overflow has an answer using `max_size_decor`, although I didn't notice it till after I'd written this myself. I had tried something very similar — limiting the length to 23 characters — but then I decided it's really only the length of the _fractional portion_ that I care about, so that's the only part I should codify the length of.

[1]: https://stackoverflow.com/questions/5947018/how-to-customize-timestamp-format-of-boost-log