### PR TITLE
Store configuration in registry

### DIFF
--- a/SettingsWatchdog/SettingsWatchdog.cpp
+++ b/SettingsWatchdog/SettingsWatchdog.cpp
@@ -563,12 +563,11 @@ int main(int argc, char* argv[])
             boost::nowide::cout << desc << std::endl;
             return EXIT_SUCCESS;
         }
-        Config config;
         if (vm.count("log-location")) {
-            config.log_file(vm.at("log-location").as<std::filesystem::path>());
+            config::log_file.set(vm.at("log-location").as<std::filesystem::path>());
         }
         if (vm.count("verbose")) {
-            config.verbosity(vm.at("verbose").as<severity_level>());
+            config::verbosity.set(vm.at("verbose").as<severity_level>());
         }
         WDLOG(info, "Running %1%") % boost::nowide::narrow(boost::dll::program_location().native());
         WDLOG(trace, "Commit %1%") % git_commit;

--- a/SettingsWatchdog/SettingsWatchdog.cpp
+++ b/SettingsWatchdog/SettingsWatchdog.cpp
@@ -9,6 +9,7 @@
 #include <sddl.h>
 
 #include <algorithm>
+#include <exception>
 #include <experimental/map>
 #include <functional>
 #include <map>
@@ -594,6 +595,9 @@ int main(int argc, char* argv[])
         return EXIT_SUCCESS;
     } catch (std::system_error const& ex) {
         WDLOG(error, "Error (%1%) %2%") % ex.code() % boost::algorithm::trim_copy(std::string(ex.what()));
+        return EXIT_FAILURE;
+    } catch (std::exception const& ex) {
+        WDLOG(error, "Error: %1%") % boost::algorithm::trim_copy(std::string(ex.what()));
         return EXIT_FAILURE;
     }
 }

--- a/SettingsWatchdog/SettingsWatchdog.cpp
+++ b/SettingsWatchdog/SettingsWatchdog.cpp
@@ -1,3 +1,4 @@
+#include "config.hpp"
 #include "string-maps.hpp"
 #include "registry.hpp"
 #include "logging.hpp"
@@ -545,14 +546,13 @@ int main(int argc, char* argv[])
     try {
         boost::nowide::args a(argc, argv);
 
-        WDLOG(info, "Running %1%") % boost::nowide::narrow(boost::dll::program_location().native());
-        WDLOG(trace, "Commit %1%") % git_commit;
-
         po::options_description desc("Allowed options");
         desc.add_options()
             ("help,h", "This help message")
             ("install,i", "Install the service")
             ("uninstall,u", "Uninstall the service")
+            ("log-location,l", po::value<std::filesystem::path>(), "Set the location of the log file")
+            ("verbose,v", po::value<severity_level>(), "Set the verbosity level")
             ;
         po::variables_map vm;
         po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -562,6 +562,16 @@ int main(int argc, char* argv[])
             boost::nowide::cout << desc << std::endl;
             return EXIT_SUCCESS;
         }
+        Config config;
+        if (vm.count("log-location")) {
+            config.log_file(vm.at("log-location").as<std::filesystem::path>());
+        }
+        if (vm.count("verbose")) {
+            config.verbosity(vm.at("verbose").as<severity_level>());
+        }
+        WDLOG(info, "Running %1%") % boost::nowide::narrow(boost::dll::program_location().native());
+        WDLOG(trace, "Commit %1%") % git_commit;
+
         if (vm.count("install")) {
             InstallService();
             return EXIT_SUCCESS;

--- a/SettingsWatchdog/config.cpp
+++ b/SettingsWatchdog/config.cpp
@@ -1,12 +1,27 @@
 #include "config.hpp"
 #include "logging.hpp"
 
+static std::filesystem::path g_log(R"(C:\SettingsWatchdog.log)");
+static severity_level g_verbose = severity_level::trace;
+
 std::filesystem::path Config::log_file() const
 {
-    return R"(C:\SettingsWatchdog.log)";
+    return g_log;
+}
+
+Config& Config::log_file(std::filesystem::path const& path)
+{
+    g_log = path;
+    return *this;
 }
 
 severity_level Config::verbosity() const
 {
-    return severity_level::trace;
+    return g_verbose;
+}
+
+Config& Config::verbosity(severity_level const& sev)
+{
+    g_verbose = sev;
+    return *this;
 }

--- a/SettingsWatchdog/config.cpp
+++ b/SettingsWatchdog/config.cpp
@@ -1,53 +1,11 @@
 #include "config.hpp"
-#include "logging.hpp"
-#include "registry.hpp"
-#include "errors.hpp"
 
-#include <codeanalysis/warnings.h>
-#pragma warning(push)
-#pragma warning(disable: ALL_CODE_ANALYSIS_WARNINGS)
-
-#include <boost/nowide/convert.hpp>
-
-#pragma warning(pop)
-
-auto constexpr config_registry_key = R"(SOFTWARE\SettingsWatchdog)";
-static std::filesystem::path const default_log_file(R"(C:\SettingsWatchdog.log)");
-static severity_level const default_severity = severity_level::trace;
-
-std::filesystem::path Config::log_file() const
+namespace config
 {
-    try {
-        return registry::read_string(HKEY_LOCAL_MACHINE, config_registry_key, "log file");
-    } catch (std::system_error const& ex) {
-        std::error_code const ec(ERROR_FILE_NOT_FOUND, std::system_category());
-        if (ex.code() == ec)
-            return default_log_file;
-        throw;
-    }
-}
+    auto constexpr config_registry_key = R"(SOFTWARE\SettingsWatchdog)";
+    static std::filesystem::path const default_log_file(R"(C:\SettingsWatchdog.log)");
+    static severity_level const default_severity = severity_level::trace;
 
-Config& Config::log_file(std::filesystem::path const& path)
-{
-    registry::write_string(HKEY_LOCAL_MACHINE, config_registry_key, "log file", path.native());
-    return *this;
-}
-
-severity_level Config::verbosity() const
-{
-    try {
-        return registry::read_int<severity_level>(HKEY_LOCAL_MACHINE, config_registry_key, "severity level");
-    }
-    catch (std::system_error const& ex) {
-        std::error_code const ec(ERROR_FILE_NOT_FOUND, std::system_category());
-        if (ex.code() == ec)
-            return default_severity;
-        throw;
-    }
-}
-
-Config& Config::verbosity(severity_level const& sev)
-{
-    registry::write_int(HKEY_LOCAL_MACHINE, config_registry_key, "severity level", sev);
-    return *this;
+    registry::value<std::filesystem::path> log_file(HKEY_LOCAL_MACHINE, config_registry_key, "log file", default_log_file);
+    registry::value<severity_level> verbosity(HKEY_LOCAL_MACHINE, config_registry_key, "severity level", default_severity);
 }

--- a/SettingsWatchdog/config.cpp
+++ b/SettingsWatchdog/config.cpp
@@ -1,27 +1,53 @@
 #include "config.hpp"
 #include "logging.hpp"
+#include "registry.hpp"
+#include "errors.hpp"
 
-static std::filesystem::path g_log(R"(C:\SettingsWatchdog.log)");
-static severity_level g_verbose = severity_level::trace;
+#include <codeanalysis/warnings.h>
+#pragma warning(push)
+#pragma warning(disable: ALL_CODE_ANALYSIS_WARNINGS)
+
+#include <boost/nowide/convert.hpp>
+
+#pragma warning(pop)
+
+auto constexpr config_registry_key = R"(SOFTWARE\SettingsWatchdog)";
+static std::filesystem::path const default_log_file(R"(C:\SettingsWatchdog.log)");
+static severity_level const default_severity = severity_level::trace;
 
 std::filesystem::path Config::log_file() const
 {
-    return g_log;
+    try {
+        return registry::read_string(HKEY_LOCAL_MACHINE, config_registry_key, "log file");
+    } catch (std::system_error const& ex) {
+        std::error_code const ec(ERROR_FILE_NOT_FOUND, std::system_category());
+        if (ex.code() == ec)
+            return default_log_file;
+        throw;
+    }
 }
 
 Config& Config::log_file(std::filesystem::path const& path)
 {
-    g_log = path;
+    registry::write_string(HKEY_LOCAL_MACHINE, config_registry_key, "log file", path.native());
     return *this;
 }
 
 severity_level Config::verbosity() const
 {
-    return g_verbose;
+    try {
+        return registry::read_int<severity_level>(HKEY_LOCAL_MACHINE, config_registry_key, "severity level");
+    }
+    catch (std::system_error const& ex) {
+        std::error_code const ec(ERROR_FILE_NOT_FOUND, std::system_category());
+        if (ex.code() == ec)
+            return default_severity;
+        throw;
+    }
 }
 
 Config& Config::verbosity(severity_level const& sev)
 {
-    g_verbose = sev;
+    registry::write_int(HKEY_LOCAL_MACHINE, config_registry_key, "severity level", sev);
     return *this;
 }

--- a/SettingsWatchdog/config.hpp
+++ b/SettingsWatchdog/config.hpp
@@ -1,15 +1,21 @@
 #pragma once
 
+#include "registry.hpp"
 #include "logging.hpp"
 
 #include <filesystem>
+#include <string>
 
-class Config
+namespace registry {
+    template <>
+    struct registry_traits<std::filesystem::path> {
+        static std::wstring convert(std::filesystem::path const& p) {
+            return p.native();
+        }
+    };
+}
+namespace config
 {
-public:
-    std::filesystem::path log_file() const;
-    Config& log_file(std::filesystem::path const&);
-
-    severity_level verbosity() const;
-    Config& verbosity(severity_level const&);
-};
+    extern registry::value<std::filesystem::path> log_file;
+    extern registry::value<severity_level> verbosity;
+}

--- a/SettingsWatchdog/errors.cpp
+++ b/SettingsWatchdog/errors.cpp
@@ -1,6 +1,6 @@
 #include "errors.hpp"
 
-LONG RegCheck(LONG arg, char const* message)
+LSTATUS RegCheck(LSTATUS arg, char const* message)
 {
     if (arg != ERROR_SUCCESS) {
         std::error_code ec(arg, std::system_category());

--- a/SettingsWatchdog/errors.hpp
+++ b/SettingsWatchdog/errors.hpp
@@ -15,4 +15,4 @@ T&& WinCheck(T&& arg, char const* message)
     return std::move(arg);
 }
 
-LONG RegCheck(LONG arg, char const* message);
+LSTATUS RegCheck(LSTATUS arg, char const* message);

--- a/SettingsWatchdog/logging.cpp
+++ b/SettingsWatchdog/logging.cpp
@@ -50,13 +50,11 @@ static bl::formatter const g_formatter = (
 
 static bool severity_filter(bl::value_ref<severity_level, tag::severity> const& level)
 {
-    Config const config;
-    return level >= config.verbosity();
+    return level >= config::verbosity.get();
 }
 
 BOOST_LOG_GLOBAL_LOGGER_INIT(wdlog, logger_type)
 {
-    Config const config;
     logger_type lg;
     lg.add_attribute("TimeStamp", bl::attributes::local_clock());
     lg.add_attribute("ProcessId", bl::attributes::make_constant(boost::winapi::GetCurrentProcessId()));
@@ -71,7 +69,7 @@ BOOST_LOG_GLOBAL_LOGGER_INIT(wdlog, logger_type)
         bl::keywords::format = g_formatter
     );
     auto const file = bl::add_file_log(
-        bl::keywords::file_name = config.log_file().native(),
+        bl::keywords::file_name = config::log_file.get().native(),
         bl::keywords::open_mode = std::ios_base::app | std::ios_base::out,
         bl::keywords::auto_flush = true,
         bl::keywords::filter = verbosity_filter,

--- a/SettingsWatchdog/logging.hpp
+++ b/SettingsWatchdog/logging.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
 #include <iosfwd>
+#include <vector>
+#include <string>
 
 #include <codeanalysis/warnings.h>
 #pragma warning(push)
 #pragma warning(disable: ALL_CODE_ANALYSIS_WARNINGS)
 
+#include <boost/any.hpp>
 #include <boost/format.hpp>
 #include <boost/log/sources/global_logger_storage.hpp>
 #include <boost/log/trivial.hpp>
@@ -23,6 +26,8 @@ enum class severity_level
 };
 
 std::basic_ostream<char>& operator<<(std::basic_ostream<char>& os, severity_level sev);
+
+void validate(boost::any& v, std::vector<std::string> const& values, severity_level* target_type, int);
 
 using logger_type = boost::log::sources::severity_logger_mt<severity_level>;
 

--- a/SettingsWatchdog/registry.cpp
+++ b/SettingsWatchdog/registry.cpp
@@ -6,7 +6,6 @@
 #pragma warning(push)
 #pragma warning(disable: ALL_CODE_ANALYSIS_WARNINGS)
 
-#include <boost/log/sources/severity_feature.hpp>
 #include <boost/nowide/convert.hpp>
 
 #pragma warning(pop)
@@ -51,33 +50,5 @@ void DeleteRegistryValue(HKEY key, char const* name)
         default:
             WDLOG(error, "Error deleting %1% value: %2%") % name % result;
             break;
-    }
-}
-
-namespace registry
-{
-    std::string read_string(HKEY key, std::string const& subkey, std::string const& value_name)
-    {
-        DWORD type;
-        DWORD data_size = 0;
-        RegCheck(RegGetValueW(key, boost::nowide::widen(subkey).c_str(), boost::nowide::widen(value_name).c_str(), RRF_RT_REG_EXPAND_SZ | RRF_RT_REG_SZ, &type, nullptr, &data_size), "checking value size");
-        switch (type) {
-        case REG_EXPAND_SZ:
-        case REG_SZ: {
-            std::vector<char> buffer(data_size);
-            RegCheck(RegGetValueW(key, boost::nowide::widen(subkey).c_str(), boost::nowide::widen(value_name).c_str(), RRF_RT_REG_EXPAND_SZ | RRF_RT_REG_SZ, nullptr, buffer.data(), &data_size), "reading string value");
-            return boost::nowide::narrow(reinterpret_cast<wchar_t const*>(buffer.data()), data_size - sizeof(wchar_t));
-        }
-        default:
-            throw std::domain_error(boost::str(boost::format("unsupported registry type %1%") % ::get(registry_types, type).value_or(std::to_string(type))));
-        }
-    }
-
-    void write_string(HKEY key, std::string const& subkey, std::string const& value_name, std::string const& value) {
-        write_string(key, subkey, value_name, boost::nowide::widen(value));
-    }
-
-    void write_string(HKEY key, std::string const& subkey, std::string const& value_name, std::wstring const& value) {
-        RegCheck(RegSetKeyValueW(key, boost::nowide::widen(subkey).c_str(), boost::nowide::widen(value_name).c_str(), REG_SZ, reinterpret_cast<BYTE const*>(value.data()), boost::numeric_cast<DWORD>((value.size() + 1) * sizeof(wchar_t))), "storing string value");
     }
 }

--- a/SettingsWatchdog/registry.cpp
+++ b/SettingsWatchdog/registry.cpp
@@ -11,7 +11,7 @@
 
 #pragma warning(pop)
 
-HKEY OpenRegKey(HKEY hKey, char const* lpSubKey, DWORD ulOptions, REGSAM samDesired)
+static HKEY OpenRegKey(HKEY hKey, char const* lpSubKey, DWORD ulOptions, REGSAM samDesired)
 {
     HKEY result;
     RegCheck(RegOpenKeyExW(hKey, boost::nowide::widen(lpSubKey).c_str(), ulOptions, samDesired, &result), "opening registry key");

--- a/SettingsWatchdog/registry.cpp
+++ b/SettingsWatchdog/registry.cpp
@@ -53,3 +53,31 @@ void DeleteRegistryValue(HKEY key, char const* name)
             break;
     }
 }
+
+namespace registry
+{
+    std::string read_string(HKEY key, std::string const& subkey, std::string const& value_name)
+    {
+        DWORD type;
+        DWORD data_size = 0;
+        RegCheck(RegGetValueW(key, boost::nowide::widen(subkey).c_str(), boost::nowide::widen(value_name).c_str(), RRF_RT_REG_EXPAND_SZ | RRF_RT_REG_SZ, &type, nullptr, &data_size), "checking value size");
+        switch (type) {
+        case REG_EXPAND_SZ:
+        case REG_SZ: {
+            std::vector<char> buffer(data_size);
+            RegCheck(RegGetValueW(key, boost::nowide::widen(subkey).c_str(), boost::nowide::widen(value_name).c_str(), RRF_RT_REG_EXPAND_SZ | RRF_RT_REG_SZ, nullptr, buffer.data(), &data_size), "reading string value");
+            return boost::nowide::narrow(reinterpret_cast<wchar_t const*>(buffer.data()), data_size - sizeof(wchar_t));
+        }
+        default:
+            throw std::domain_error(boost::str(boost::format("unsupported registry type %1%") % ::get(registry_types, type).value_or(std::to_string(type))));
+        }
+    }
+
+    void write_string(HKEY key, std::string const& subkey, std::string const& value_name, std::string const& value) {
+        write_string(key, subkey, value_name, boost::nowide::widen(value));
+    }
+
+    void write_string(HKEY key, std::string const& subkey, std::string const& value_name, std::wstring const& value) {
+        RegCheck(RegSetKeyValueW(key, boost::nowide::widen(subkey).c_str(), boost::nowide::widen(value_name).c_str(), REG_SZ, reinterpret_cast<BYTE const*>(value.data()), boost::numeric_cast<DWORD>((value.size() + 1) * sizeof(wchar_t))), "storing string value");
+    }
+}

--- a/SettingsWatchdog/registry.hpp
+++ b/SettingsWatchdog/registry.hpp
@@ -1,6 +1,69 @@
 #pragma once
+#include "errors.hpp"
+#include "string-maps.hpp"
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <vector>
 
 #include <windows.h>
+
+#include <codeanalysis/warnings.h>
+#pragma warning(push)
+#pragma warning(disable: ALL_CODE_ANALYSIS_WARNINGS)
+
+#include <boost/assert.hpp>
+#include <boost/nowide/convert.hpp>
+#include <boost/numeric/conversion/cast.hpp>
+
+#pragma warning(pop)
+
+namespace registry
+{
+    std::string read_string(HKEY key, std::string const& subkey, std::string const& value_name);
+    void write_string(HKEY key, std::string const& subkey, std::string const& value_name, std::string const& value);
+    void write_string(HKEY key, std::string const& subkey, std::string const& value_name, std::wstring const& value);
+
+    template <typename T>
+    std::enable_if_t<std::disjunction_v<std::is_integral<T>, std::is_enum<T>>, T>
+    read_int(HKEY key, std::string const& subkey, std::string const& value_name)
+    {
+        DWORD type;
+        DWORD data_size = 0;
+        RegCheck(RegGetValueW(key, boost::nowide::widen(subkey).c_str() , boost::nowide::widen(value_name).c_str(), RRF_RT_REG_DWORD | RRF_RT_REG_QWORD, &type, nullptr, &data_size), "checking value size");
+        switch (type) {
+        case REG_DWORD: {
+            DWORD result;
+            BOOST_ASSERT(data_size == sizeof result);
+            data_size = sizeof result;
+            RegCheck(RegGetValueW(key, boost::nowide::widen(subkey).c_str(), boost::nowide::widen(value_name).c_str(), RRF_RT_REG_DWORD, nullptr, &result, &data_size), "reading dword value");
+            return boost::numeric_cast<T>(result);
+        }
+        case REG_QWORD: {
+            int64_t result;
+            BOOST_ASSERT(data_size == sizeof result);
+            data_size = sizeof result;
+            RegCheck(RegGetValueW(key, boost::nowide::widen(subkey).c_str(), boost::nowide::widen(value_name).c_str(), RRF_RT_REG_QWORD, nullptr, &result, &data_size), "reading qword value");
+            return boost::numeric_cast<T>(result);
+        }
+        default:
+            throw std::domain_error(boost::str(boost::format("unsupported registry type %1%") % ::get(registry_types, type).value_or(std::to_string(type))));
+        }
+    }
+
+    template <typename T>
+    std::enable_if_t<std::disjunction_v<std::is_integral<T>, std::is_enum<T>>>
+    write_int(HKEY key, std::string const& subkey, std::string const& value_name, T value)
+    {
+        using store_type = std::conditional_t<sizeof value <= sizeof(DWORD), DWORD, int64_t>;
+        static_assert(sizeof(store_type) >= sizeof value);
+        store_type const store_value = static_cast<store_type>(value);
+        DWORD const type = std::conditional_t<sizeof value <= sizeof(DWORD), std::integral_constant<DWORD, REG_DWORD>, std::integral_constant<DWORD, REG_QWORD>>::value;
+        RegCheck(RegSetKeyValueW(key, boost::nowide::widen(subkey).c_str(), boost::nowide::widen(value_name).c_str(), type, reinterpret_cast<BYTE const*>(&store_value), sizeof store_value), "storing int value");
+    }
+}
 
 class RegKey
 {

--- a/SettingsWatchdog/registry.hpp
+++ b/SettingsWatchdog/registry.hpp
@@ -2,8 +2,6 @@
 
 #include <windows.h>
 
-HKEY OpenRegKey(HKEY hKey, char const* lpSubKey, DWORD ulOptions, REGSAM samDesired);
-
 class RegKey
 {
     HKEY m_key;

--- a/SettingsWatchdog/registry.hpp
+++ b/SettingsWatchdog/registry.hpp
@@ -22,47 +22,123 @@
 
 namespace registry
 {
-    std::string read_string(HKEY key, std::string const& subkey, std::string const& value_name);
-    void write_string(HKEY key, std::string const& subkey, std::string const& value_name, std::string const& value);
-    void write_string(HKEY key, std::string const& subkey, std::string const& value_name, std::wstring const& value);
+    template <typename T>
+    struct registry_traits {
+        // static U convert(T const&);
+    };
 
     template <typename T>
-    std::enable_if_t<std::disjunction_v<std::is_integral<T>, std::is_enum<T>>, T>
-    read_int(HKEY key, std::string const& subkey, std::string const& value_name)
-    {
-        DWORD type;
-        DWORD data_size = 0;
-        RegCheck(RegGetValueW(key, boost::nowide::widen(subkey).c_str() , boost::nowide::widen(value_name).c_str(), RRF_RT_REG_DWORD | RRF_RT_REG_QWORD, &type, nullptr, &data_size), "checking value size");
-        switch (type) {
-        case REG_DWORD: {
-            DWORD result;
-            BOOST_ASSERT(data_size == sizeof result);
-            data_size = sizeof result;
-            RegCheck(RegGetValueW(key, boost::nowide::widen(subkey).c_str(), boost::nowide::widen(value_name).c_str(), RRF_RT_REG_DWORD, nullptr, &result, &data_size), "reading dword value");
-            return boost::numeric_cast<T>(result);
-        }
-        case REG_QWORD: {
-            int64_t result;
-            BOOST_ASSERT(data_size == sizeof result);
-            data_size = sizeof result;
-            RegCheck(RegGetValueW(key, boost::nowide::widen(subkey).c_str(), boost::nowide::widen(value_name).c_str(), RRF_RT_REG_QWORD, nullptr, &result, &data_size), "reading qword value");
-            return boost::numeric_cast<T>(result);
-        }
-        default:
-            throw std::domain_error(boost::str(boost::format("unsupported registry type %1%") % ::get(registry_types, type).value_or(std::to_string(type))));
-        }
-    }
+    class value {
+        HKEY const m_key;
+        std::wstring const m_subkey;
+        std::wstring const m_value_name;
+        T const m_default_value;
+    public:
+        value(HKEY key, std::string const& subkey, std::string const& value_name, T const& default_value):
+            m_key(key),
+            m_subkey(boost::nowide::widen(subkey)),
+            m_value_name(boost::nowide::widen(value_name)),
+            m_default_value(default_value)
+        {}
+        value(HKEY key, std::string const& subkey, std::string const& value_name, T&& default_value):
+            m_key(key),
+            m_subkey(boost::nowide::widen(subkey)),
+            m_value_name(boost::nowide::widen(value_name)),
+            m_default_value(std::forward<T>(default_value))
+        {}
 
-    template <typename T>
-    std::enable_if_t<std::disjunction_v<std::is_integral<T>, std::is_enum<T>>>
-    write_int(HKEY key, std::string const& subkey, std::string const& value_name, T value)
-    {
-        using store_type = std::conditional_t<sizeof value <= sizeof(DWORD), DWORD, int64_t>;
-        static_assert(sizeof(store_type) >= sizeof value);
-        store_type const store_value = static_cast<store_type>(value);
-        DWORD const type = std::conditional_t<sizeof value <= sizeof(DWORD), std::integral_constant<DWORD, REG_DWORD>, std::integral_constant<DWORD, REG_QWORD>>::value;
-        RegCheck(RegSetKeyValueW(key, boost::nowide::widen(subkey).c_str(), boost::nowide::widen(value_name).c_str(), type, reinterpret_cast<BYTE const*>(&store_value), sizeof store_value), "storing int value");
-    }
+        template <typename U>
+        void set(U const& new_value) {
+            if constexpr (std::disjunction_v<std::is_integral<T>, std::is_enum<T>>) {
+                using store_type = std::conditional_t<sizeof new_value <= sizeof(DWORD), DWORD, int64_t>;
+                store_type const store_value = static_cast<store_type>(new_value);
+                static_assert(sizeof store_value >= sizeof new_value);
+                DWORD const type = std::conditional_t<
+                    sizeof new_value <= sizeof(DWORD),
+                    std::integral_constant<DWORD, REG_DWORD>,
+                    std::integral_constant<DWORD, REG_QWORD>>::value;
+                RegCheck(RegSetKeyValueW(m_key, m_subkey.c_str(), m_value_name.c_str(), type, reinterpret_cast<BYTE const*>(&store_value), sizeof store_value), "storing int value");
+            }
+            else if constexpr (std::is_same_v<U, std::string>) {
+                set(boost::nowide::widen(new_value));
+            }
+            else if constexpr (std::is_same_v<U, std::wstring>) {
+                RegCheck(RegSetKeyValueW(m_key, m_subkey.c_str(), m_value_name.c_str(), REG_SZ, reinterpret_cast<BYTE const*>(new_value.data()), boost::numeric_cast<DWORD>((new_value.size() + 1) * sizeof(wchar_t))), "storing string value");
+            }
+            else {
+                set(registry_traits<U>::convert(new_value));
+            }
+        }
+
+        std::enable_if_t<
+            std::disjunction_v<
+                std::is_integral<T>,
+                std::is_enum<T>,
+                std::is_constructible<T, std::string>,
+                std::is_constructible<T, std::wstring>
+            >,
+            T
+        > get() const {
+            DWORD constexpr acceptible_types = std::conditional_t<
+                std::disjunction_v<
+                    std::is_integral<T>,
+                    std::is_enum<T>
+                >,
+                std::integral_constant<DWORD, RRF_RT_REG_DWORD | RRF_RT_REG_QWORD>,
+                std::integral_constant<DWORD, RRF_RT_REG_EXPAND_SZ | RRF_RT_REG_SZ>
+            >::value;
+            DWORD type;
+            DWORD data_size = 0;
+            switch (LSTATUS const reg_result = RegGetValueW(m_key, m_subkey.c_str(), m_value_name.c_str(), acceptible_types, &type, nullptr, &data_size); reg_result) {
+            default:
+                RegCheck(reg_result, "checking value size");
+                break; // not reached.
+            case ERROR_FILE_NOT_FOUND:
+                break;
+            case ERROR_SUCCESS:
+                if constexpr (std::disjunction_v<std::is_integral<T>, std::is_enum<T>>) {
+                    switch (type) {
+                    case REG_DWORD: {
+                        DWORD result;
+                        BOOST_ASSERT(data_size == sizeof result);
+                        data_size = sizeof result;
+                        RegCheck(RegGetValueW(m_key, m_subkey.c_str(), m_value_name.c_str(), RRF_RT_REG_DWORD, nullptr, &result, &data_size), "reading dword value");
+                        return boost::numeric_cast<T>(result);
+                    }
+                    case REG_QWORD: {
+                        int64_t result;
+                        BOOST_ASSERT(data_size == sizeof result);
+                        data_size = sizeof result;
+                        RegCheck(RegGetValueW(m_key, m_subkey.c_str(), m_value_name.c_str(), RRF_RT_REG_QWORD, nullptr, &result, &data_size), "reading qword value");
+                        return boost::numeric_cast<T>(result);
+                    }
+                    default:
+                        throw std::domain_error(boost::str(boost::format("unsupported registry type %1%") % ::get(registry_types, type).value_or(std::to_string(type))));
+                    }
+                }
+                else if constexpr (std::disjunction_v<std::is_constructible<T, std::string>, std::is_constructible<T, std::wstring>>) {
+                    DWORD type;
+                    DWORD data_size = 0;
+                    RegCheck(RegGetValueW(m_key, m_subkey.c_str(), m_value_name.c_str(), RRF_RT_REG_EXPAND_SZ | RRF_RT_REG_SZ, &type, nullptr, &data_size), "checking value size");
+                    switch (type) {
+                    case REG_EXPAND_SZ:
+                    case REG_SZ: {
+                        std::vector<unsigned char> buffer(data_size);
+                        RegCheck(RegGetValueW(m_key, m_subkey.c_str(), m_value_name.c_str(), RRF_RT_REG_EXPAND_SZ | RRF_RT_REG_SZ, nullptr, buffer.data(), &data_size), "reading string value");
+                        std::wstring const result(reinterpret_cast<wchar_t const*>(buffer.data()), data_size / sizeof(wchar_t) - 1);
+                        if constexpr (!std::is_constructible_v<T, std::wstring>) {
+                            return boost::nowide::narrow(result);
+                        }
+                        return std::wstring(reinterpret_cast<wchar_t const*>(buffer.data()), data_size / sizeof(wchar_t) - 1);
+                    }
+                    default:
+                        throw std::domain_error(boost::str(boost::format("unsupported registry type %1%") % ::get(registry_types, type).value_or(std::to_string(type))));
+                    }
+                }
+            }
+            return m_default_value;
+        }
+    };
 }
 
 class RegKey

--- a/SettingsWatchdog/string-maps.cpp
+++ b/SettingsWatchdog/string-maps.cpp
@@ -48,6 +48,21 @@ std::map<DWORD, std::string> const wait_results
     VALUE_NAME(WAIT_FAILED),
 };
 
+std::map<DWORD, std::string> const registry_types
+{
+    VALUE_NAME(REG_BINARY),
+    VALUE_NAME(REG_DWORD),
+    VALUE_NAME(REG_DWORD_LITTLE_ENDIAN),
+    VALUE_NAME(REG_DWORD_BIG_ENDIAN),
+    VALUE_NAME(REG_EXPAND_SZ),
+    VALUE_NAME(REG_LINK),
+    VALUE_NAME(REG_MULTI_SZ),
+    VALUE_NAME(REG_NONE),
+    VALUE_NAME(REG_QWORD),
+    VALUE_NAME(REG_QWORD_LITTLE_ENDIAN),
+    VALUE_NAME(REG_SZ),
+};
+
 std::map<severity_level, std::string> const severity_names
 {
     { severity_level::trace, "trace" },

--- a/SettingsWatchdog/string-maps.hpp
+++ b/SettingsWatchdog/string-maps.hpp
@@ -15,6 +15,8 @@ extern std::map<DWORD, std::string> const session_change_codes;
 
 extern std::map<DWORD, std::string> const wait_results;
 
+extern std::map<DWORD, std::string> const registry_types;
+
 extern std::map<severity_level, std::string> const severity_names;
 
 template <typename Map, typename T>

--- a/vcpkg-response.txt
+++ b/vcpkg-response.txt
@@ -1,4 +1,5 @@
 boost-algorithm
+boost-any
 boost-core
 boost-date-time
 boost-dll


### PR DESCRIPTION
This introduces several changes related to configuration in the registry. The logging location is configurable, as is the verbosity, which is currently conflated with severity, which might be a separate issue to fix.