### PR TITLE
Bump setup-msbuild version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
         submodules: true
 
     - name: Add MSBuild
-      uses: microsoft/setup-msbuild@v1.0.1
+      uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Install & build vcpkg packages
       uses: lukka/run-vcpkg@v4


### PR DESCRIPTION
This should resolve the error GitHub currently issues about using the `add-path` command.

I was under the impression that Dependabot would take care of this automatically because of the pcsz2 3799 pull request. However, that project didn't get its build dependency updated automatically, either, so maybe that's not really how it works at all.