### PR TITLE
Use std::format instead of boost::format

### DIFF
--- a/SettingsWatchdog/logging.hpp
+++ b/SettingsWatchdog/logging.hpp
@@ -5,7 +5,6 @@ DISABLE_ANALYSIS
 #include <vector>
 
 #include <boost/any.hpp>
-#include <boost/format.hpp>
 #include <boost/log/sources/global_logger_storage.hpp>
 #include <boost/log/trivial.hpp>
 REENABLE_ANALYSIS
@@ -28,4 +27,4 @@ using logger_type = boost::log::sources::severity_logger_mt<severity_level>;
 
 BOOST_LOG_GLOBAL_LOGGER(wdlog, logger_type)
 
-#define WDLOG(sev, msg) BOOST_LOG_SEV(wdlog::get(), (severity_level::sev)) << boost::format((msg))
+#define WDLOG(sev) BOOST_LOG_SEV(wdlog::get(), (severity_level::sev))

--- a/SettingsWatchdog/registry.cpp
+++ b/SettingsWatchdog/registry.cpp
@@ -38,13 +38,13 @@ void DeleteRegistryValue(HKEY key, char const* name)
 {
     switch (LONG const result = RegDeleteValueW(key, boost::nowide::widen(name).c_str()); result) {
         case ERROR_SUCCESS:
-            WDLOG(info, "Deleted %1% value") % name;
+            WDLOG(info) << std::format("Deleted {} value", name);
             break;
         case ERROR_FILE_NOT_FOUND:
-            WDLOG(trace, "%1% value does not exist") % name;
+            WDLOG(trace) << std::format("{} value does not exist", name);
             break;
         default:
-            WDLOG(error, "Error deleting %1% value: %2%") % name % result;
+            WDLOG(error) << std::format("Error deleting {} value: {}", name, result);
             break;
     }
 }

--- a/SettingsWatchdog/registry.hpp
+++ b/SettingsWatchdog/registry.hpp
@@ -1,6 +1,7 @@
 #pragma once
 DISABLE_ANALYSIS
 #include <cstdint>
+#include <format>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -114,8 +115,8 @@ namespace registry
                             }
                             default:
                                 throw std::domain_error(
-                                    boost::str(boost::format("unsupported registry type %1%")
-                                               % ::get(registry_types, type).value_or(std::to_string(type))));
+                                    std::format("unsupported registry type {}",
+                                                ::get(registry_types, type).value_or(std::to_string(type))));
                         }
                     } else if constexpr (std::disjunction_v<std::is_constructible<T, std::string>,
                                                             std::is_constructible<T, std::wstring>>) {
@@ -142,8 +143,8 @@ namespace registry
                             }
                             default:
                                 throw std::domain_error(
-                                    boost::str(boost::format("unsupported registry type %1%")
-                                               % ::get(registry_types, type).value_or(std::to_string(type))));
+                                    std::format("unsupported registry type {}",
+                                                ::get(registry_types, type).value_or(std::to_string(type))));
                         }
                     }
             }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,7 +8,6 @@
     "boost-core",
     "boost-date-time",
     "boost-dll",
-    "boost-format",
     "boost-log",
     "boost-nowide",
     "boost-numeric-conversion",


### PR DESCRIPTION
This reduces the number of direct dependencies, although other parts of Boost surely still use Boost.Format, so build times probably won't change much.