### PR TITLE
Consolidate AutoFreeString specializations

### DIFF
--- a/SettingsWatchdog/SettingsWatchdog.cpp
+++ b/SettingsWatchdog/SettingsWatchdog.cpp
@@ -45,19 +45,17 @@ auto const SystemPolicyKey = R"(SOFTWARE\Microsoft\Windows\CurrentVersion\Polici
 auto const DesktopPolicyKey = R"(Control Panel\Desktop)";
 DWORD const ServiceType = SERVICE_WIN32_OWN_PROCESS;
 
-template <typename T>
+template <void (*FREE)(void*)>
 class AutoFreeString: private boost::noncopyable
 {
 private:
     wchar_t* m_value = NULL;
     std::string mutable m_narrow_value;
-    AutoFreeString() = default;
-    friend T;
 
 public:
     ~AutoFreeString()
     {
-        T::free(m_value);
+        FREE(m_value);
     }
     wchar_t** operator&()
     {
@@ -70,23 +68,8 @@ public:
     }
 };
 
-class WTSString: public AutoFreeString<WTSString>
-{
-public:
-    static void free(wchar_t* value)
-    {
-        WTSFreeMemory(value);
-    }
-};
-
-class LocalString: public AutoFreeString<LocalString>
-{
-public:
-    static void free(wchar_t* value)
-    {
-        LocalFree(value);
-    }
-};
+using WTSString = AutoFreeString<[](void* arg) { WTSFreeMemory(arg); }>;
+using LocalString = AutoFreeString<[](void* arg) { LocalFree(arg); }>;
 
 void InstallService()
 {


### PR DESCRIPTION
C++20 lets us pass const non-literals for non-type template parameters, which includes lambda functions (and ordinary functions). That means we don't need to make an explicit template specialization just to provide the `free` function for each string type. Instead, we can use a one-line `using` definition.