### PR TITLE
Recover when registry isn't writeable

### DIFF
--- a/SettingsWatchdog/SettingsWatchdog.cpp
+++ b/SettingsWatchdog/SettingsWatchdog.cpp
@@ -589,10 +589,26 @@ int main(int argc, char* argv[])
             return EXIT_SUCCESS;
         }
         if (vm.contains("log-location")) {
-            config::log_file.set(vm.at("log-location").as<std::filesystem::path>());
+            try {
+                config::log_file.set(vm.at("log-location").as<std::filesystem::path>());
+            } catch (std::system_error const& ex) {
+                std::error_code const error_access_denied(ERROR_ACCESS_DENIED, std::system_category());
+                if (ex.code() != error_access_denied) {
+                    throw;
+                }
+                // We're unable to store the log location. No big deal.
+            }
         }
         if (vm.contains("verbose")) {
-            config::verbosity.set(vm.at("verbose").as<severity_level>());
+            try {
+                config::verbosity.set(vm.at("verbose").as<severity_level>());
+            } catch (std::system_error const& ex) {
+                std::error_code const error_access_denied(ERROR_ACCESS_DENIED, std::system_category());
+                if (ex.code() != error_access_denied) {
+                    throw;
+                }
+                // We're unable to store the verbosity. No big deal.
+            }
         }
         WDLOG(info) << std::format("Running {}", boost::nowide::narrow(boost::dll::program_location().native()));
         WDLOG(trace) << std::format("Commit {}", git_commit);


### PR DESCRIPTION
Registry values in code will now remember the values assigned to them, so if they're not allowed to write, they're still functional. When reading, they'll try to read the current value, but return the last stored value if available.